### PR TITLE
Add automated log rotation and retention controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ details.
 For smart home integration instructions see
 [`docs/SmartHome_Setup.md`](docs/SmartHome_Setup.md).
 
+### Log rotation
 
+The assistant writes JSONL logs under `logs/`. `scripts/log_rotation.py` runs in
+the background (started by `scripts.voice_loop_stub`) and rotates `stt.jsonl`,
+`llm.jsonl` and similar files once per day or when they exceed a configurable
+size. Archived logs are compressed and removed after 30 days by default.
+Adjust `LOG_ROTATION_SIZE_MB` and `LOG_RETENTION_DAYS` to tweak these settings.
 
 ### Environment configuration
 

--- a/scripts/log_rotation.py
+++ b/scripts/log_rotation.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Utility for rotating log files and pruning old archives.
+
+This module checks JSONL log files under ``logs/`` (e.g. ``stt.jsonl`` and
+``llm.jsonl``) and rotates them either when the file grows beyond a size
+threshold or when a new day begins.  Rotated logs are compressed to
+``.gz`` archives and older archives are deleted after a retention period.
+
+Environment variables
+---------------------
+``LOG_ROTATION_SIZE_MB``  Size threshold in megabytes (default: 5).
+``LOG_RETENTION_DAYS``    Number of days to keep archived logs (default: 30).
+``LOG_DIR``               Base directory for logs (default: ``logs``).
+"""
+from __future__ import annotations
+
+import gzip
+import os
+import shutil
+import threading
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable
+
+
+def rotate_logs(log_files: Iterable[Path], size_threshold: int, retention_days: int) -> None:
+    """Rotate and prune the given log files.
+
+    Parameters
+    ----------
+    log_files:
+        Iterable of log file paths to examine.
+    size_threshold:
+        Maximum allowed size in bytes before rotation occurs.
+    retention_days:
+        Age in days after which archived logs are removed.
+    """
+    now = datetime.utcnow()
+    today = now.date()
+
+    for path in log_files:
+        if not path.exists():
+            continue
+        stat = path.stat()
+        file_date = datetime.utcfromtimestamp(stat.st_mtime).date()
+        if stat.st_size >= size_threshold or file_date < today:
+            timestamp = now.strftime("%Y%m%d_%H%M%S")
+            rotated = path.with_name(f"{path.stem}-{timestamp}{path.suffix}")
+            path.rename(rotated)
+            # Compress rotated file
+            with open(rotated, "rb") as src, gzip.open(f"{rotated}.gz", "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            rotated.unlink()
+
+    # Prune old archives
+    cutoff = now - timedelta(days=retention_days)
+    log_dir = Path(log_files[0]).parent if log_files else Path(os.getenv("LOG_DIR", "logs"))
+    for archive in log_dir.glob("*.gz"):
+        mtime = datetime.utcfromtimestamp(archive.stat().st_mtime)
+        if mtime < cutoff:
+            archive.unlink(missing_ok=True)
+
+
+def rotate_logs_periodically(
+    interval_seconds: int = 24 * 60 * 60,
+    log_files: Iterable[Path] | None = None,
+    size_mb: int | None = None,
+    retention_days: int | None = None,
+) -> threading.Thread:
+    """Start a background thread that periodically rotates logs."""
+    log_dir = Path(os.getenv("LOG_DIR", "logs"))
+    default_files = [log_dir / "stt.jsonl", log_dir / "llm.jsonl"]
+    files = list(log_files) if log_files else default_files
+    size_threshold = int((size_mb or int(os.getenv("LOG_ROTATION_SIZE_MB", "5"))) * 1024 * 1024)
+    retention = retention_days or int(os.getenv("LOG_RETENTION_DAYS", "30"))
+
+    def loop() -> None:
+        while True:
+            try:
+                rotate_logs(files, size_threshold, retention)
+            except Exception:
+                pass
+            time.sleep(interval_seconds)
+
+    t = threading.Thread(target=loop, daemon=True)
+    t.start()
+    return t
+
+
+def main() -> None:
+    """Run a single rotation pass using default settings."""
+    log_dir = Path(os.getenv("LOG_DIR", "logs"))
+    log_files = [log_dir / "stt.jsonl", log_dir / "llm.jsonl"]
+    size_threshold = int(os.getenv("LOG_ROTATION_SIZE_MB", "5")) * 1024 * 1024
+    retention_days = int(os.getenv("LOG_RETENTION_DAYS", "30"))
+    rotate_logs(log_files, size_threshold, retention_days)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/voice_loop_stub.py
+++ b/scripts/voice_loop_stub.py
@@ -47,6 +47,7 @@ from pathlib import Path
 from typing import Optional
 
 from osc_bridge_stub import send_mouth_open, send_pad
+from log_rotation import rotate_logs_periodically
 
 try:
     from smarthome_bridge import SmartHomeBridge  # type: ignore
@@ -251,12 +252,14 @@ def main() -> None:
     # Select STT/TTS engines
     stt = select_stt()
     tts = select_tts()
- codex/resolve-conflict-in-readme.md-5fi9ql
+
+    # Start periodic log rotation
+    rotate_logs_periodically()
 
     # Optional smart home helpers
     bridge = SmartHomeBridge() if SmartHomeBridge else None
     parser = SmartHomeCommandParser() if SmartHomeCommandParser else None
- main
+
     print("Voice loop ready. Say the wake word to begin.")
     # Start wake word detection
     def on_wake():


### PR DESCRIPTION
## Summary
- add `scripts/log_rotation.py` to rotate STT/LLM logs by date or size and purge old archives
- start log rotation thread inside `scripts/voice_loop_stub` so long-running sessions clean up logs automatically
- document log rotation and retention environment variables in README

## Testing
- `python -m py_compile scripts/voice_loop_stub.py`
- `python -m py_compile scripts/log_rotation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0660bd100832eaf127af914713ab6