### PR TITLE
Add phone and book interaction scripts for avatar

### DIFF
--- a/unity_project/Assets/Scripts/Avatar/BookInteraction.cs
+++ b/unity_project/Assets/Scripts/Avatar/BookInteraction.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// Handles spawning and cleanup of a book prop for the avatar.
+/// </summary>
+public class BookInteraction : MonoBehaviour
+{
+    public GameObject bookPrefab;
+    public Transform leftHand;
+    public Animator animator;
+    [Tooltip("Animator trigger to start reading.")]
+    public string readTrigger = "ReadBook";
+    [Tooltip("Animator state name representing reading.")]
+    public string readStateName = "ReadBook";
+
+    GameObject bookInstance;
+
+    /// <summary>
+    /// Spawn the book, attach it to the hand and start the animation.
+    /// </summary>
+    public void StartReading()
+    {
+        if (bookInstance != null) return;
+        if (bookPrefab == null || leftHand == null || animator == null) return;
+
+        bookInstance = Instantiate(bookPrefab, leftHand);
+        bookInstance.transform.localPosition = Vector3.zero;
+        bookInstance.transform.localRotation = Quaternion.identity;
+
+        animator.SetTrigger(readTrigger);
+        StartCoroutine(MonitorReadingState());
+    }
+
+    IEnumerator MonitorReadingState()
+    {
+        // Wait for the state to start.
+        while (!animator.GetCurrentAnimatorStateInfo(0).IsName(readStateName))
+            yield return null;
+        // Wait for the state to finish.
+        while (animator.GetCurrentAnimatorStateInfo(0).IsName(readStateName))
+            yield return null;
+        EndReading();
+    }
+
+    void EndReading()
+    {
+        if (bookInstance != null)
+        {
+            Destroy(bookInstance);
+            bookInstance = null;
+        }
+    }
+
+    void OnDisable()
+    {
+        EndReading();
+    }
+}
+

--- a/unity_project/Assets/Scripts/Avatar/PhoneInteraction.cs
+++ b/unity_project/Assets/Scripts/Avatar/PhoneInteraction.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using UnityEngine;
+
+/// <summary>
+/// Handles spawning and cleanup of a phone prop for the avatar.
+/// </summary>
+public class PhoneInteraction : MonoBehaviour
+{
+    public GameObject phonePrefab;
+    public Transform rightHand;
+    public Animator animator;
+    [Tooltip("Animator trigger to start phone usage.")]
+    public string phoneTrigger = "UsePhone";
+    [Tooltip("Animator state name representing phone usage.")]
+    public string phoneStateName = "UsePhone";
+
+    GameObject phoneInstance;
+
+    /// <summary>
+    /// Spawn the phone, attach it to the hand and start the animation.
+    /// </summary>
+    public void StartPhoneUse()
+    {
+        if (phoneInstance != null) return;
+        if (phonePrefab == null || rightHand == null || animator == null) return;
+
+        phoneInstance = Instantiate(phonePrefab, rightHand);
+        phoneInstance.transform.localPosition = Vector3.zero;
+        phoneInstance.transform.localRotation = Quaternion.identity;
+
+        animator.SetTrigger(phoneTrigger);
+        StartCoroutine(MonitorPhoneState());
+    }
+
+    IEnumerator MonitorPhoneState()
+    {
+        // Wait for the state to start.
+        while (!animator.GetCurrentAnimatorStateInfo(0).IsName(phoneStateName))
+            yield return null;
+        // Wait for the state to finish.
+        while (animator.GetCurrentAnimatorStateInfo(0).IsName(phoneStateName))
+            yield return null;
+        EndPhoneUse();
+    }
+
+    void EndPhoneUse()
+    {
+        if (phoneInstance != null)
+        {
+            Destroy(phoneInstance);
+            phoneInstance = null;
+        }
+    }
+
+    void OnDisable()
+    {
+        EndPhoneUse();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `PhoneInteraction` to spawn a phone, attach it to the right hand, and trigger the phone-use animation.
- Add `BookInteraction` to spawn a book, attach it to the left hand, and trigger the reading animation.
- Both scripts expose `StartPhoneUse()` or `StartReading()` and remove props when their animations end.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afbf457484832ea209f780759f85e1