### PR TITLE
Add diagnostics HUD with WebSocket log streaming

### DIFF
--- a/scripts/log_manager.py
+++ b/scripts/log_manager.py
@@ -14,19 +14,42 @@ purposes.  It is lightweight and does not block on errors.
 from __future__ import annotations
 
 import json
+import asyncio
+import threading
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Any
+from typing import Dict, Any, Optional, Set
 
 
 class LogManager:
-    """A simple manager that writes JSON log entries to a file."""
+    """A simple manager that writes JSON log entries to a file.
 
-    def __init__(self, log_file: str | Path):
+    Optionally, log entries are broadcast over a WebSocket so that other
+    components (e.g. the in‑game diagnostics HUD) can display them in
+    real time.  The WebSocket server runs in a background thread and
+    accepts JSON messages for each log entry.
+    """
+
+    def __init__(self, log_file: str | Path, ws_port: Optional[int] = 8765):
         self.log_file = Path(log_file)
-        # Ensure parent directory exists
         if not self.log_file.parent.exists():
             self.log_file.parent.mkdir(parents=True, exist_ok=True)
+
+        self._ws_port = ws_port
+        self._ws_clients: Set[Any] = set()
+        self._ws_loop: Optional[asyncio.AbstractEventLoop] = None
+
+        if ws_port is not None:
+            try:
+                import websockets  # type: ignore
+
+                self._ws_module = websockets
+                self._ws_loop = asyncio.new_event_loop()
+                thread = threading.Thread(target=self._run_ws_server, daemon=True)
+                thread.start()
+            except Exception:
+                # If websockets fail to start, disable broadcasting silently
+                self._ws_port = None
 
     def log(self, entry: Dict[str, Any]) -> None:
         """Append a dictionary as a JSON line to the log file.
@@ -43,5 +66,38 @@ class LogManager:
                 json.dump(entry, f, ensure_ascii=False)
                 f.write("\n")
         except Exception:
-            # Silently ignore logging errors
             pass
+
+        if self._ws_port is not None and self._ws_loop is not None:
+            try:
+                message = json.dumps(entry, ensure_ascii=False)
+                asyncio.run_coroutine_threadsafe(
+                    self._broadcast(message), self._ws_loop
+                )
+            except Exception:
+                pass
+
+    # ------------------------------------------------------------------
+    # WebSocket support
+    def _run_ws_server(self) -> None:
+        if self._ws_loop is None:
+            return
+        asyncio.set_event_loop(self._ws_loop)
+        server = self._ws_module.serve(self._ws_handler, "0.0.0.0", self._ws_port)
+        self._ws_loop.run_until_complete(server)
+        self._ws_loop.run_forever()
+
+    async def _ws_handler(self, websocket, _path) -> None:
+        self._ws_clients.add(websocket)
+        try:
+            await websocket.wait_closed()
+        finally:
+            self._ws_clients.discard(websocket)
+
+    async def _broadcast(self, message: str) -> None:
+        if not self._ws_clients:
+            return
+        await asyncio.gather(
+            *[client.send(message) for client in list(self._ws_clients)],
+            return_exceptions=True,
+        )

--- a/unity_project/Assets/Scripts/UI/DiagnosticsHUD.cs
+++ b/unity_project/Assets/Scripts/UI/DiagnosticsHUD.cs
@@ -1,0 +1,144 @@
+using UnityEngine;
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text;
+
+/// <summary>
+/// Runtime diagnostics overlay that shows connection status and last errors.
+/// Connects to the Python log manager via WebSocket to receive log entries
+/// and displays the most recent error message.  The overlay can be toggled
+/// with the F3 key.
+/// </summary>
+public class DiagnosticsHUD : MonoBehaviour
+{
+    /// <summary>Key used to toggle the HUD visibility.</summary>
+    public KeyCode toggleKey = KeyCode.F3;
+
+    /// <summary>WebSocket endpoint served by scripts/log_manager.py.</summary>
+    public string websocketUrl = "ws://localhost:8765";
+
+    bool _visible = true;
+    string _oscStatus = "Unknown";
+    string _wsStatus = "Disconnected";
+    string _sttEngine = string.Empty;
+    string _ttsEngine = string.Empty;
+    string _lastError = string.Empty;
+
+    ClientWebSocket _ws;
+    CancellationTokenSource _cts;
+
+    void Start()
+    {
+        ConnectWebSocket();
+    }
+
+    async void ConnectWebSocket()
+    {
+        _ws = new ClientWebSocket();
+        _cts = new CancellationTokenSource();
+        try
+        {
+            await _ws.ConnectAsync(new Uri(websocketUrl), _cts.Token);
+            _wsStatus = "Connected";
+            _ = ReceiveLoop();
+        }
+        catch (Exception ex)
+        {
+            _wsStatus = "Error";
+            _lastError = ex.Message;
+        }
+    }
+
+    async Task ReceiveLoop()
+    {
+        var buffer = new byte[2048];
+        while (_ws != null && _ws.State == WebSocketState.Open)
+        {
+            try
+            {
+                var result = await _ws.ReceiveAsync(new ArraySegment<byte>(buffer), _cts.Token);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await _ws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, _cts.Token);
+                    _wsStatus = "Closed";
+                }
+                else
+                {
+                    var msg = Encoding.UTF8.GetString(buffer, 0, result.Count);
+                    ProcessLogMessage(msg);
+                }
+            }
+            catch (Exception ex)
+            {
+                _wsStatus = "Error";
+                _lastError = ex.Message;
+                break;
+            }
+        }
+    }
+
+    void ProcessLogMessage(string msg)
+    {
+        try
+        {
+            var entry = JsonUtility.FromJson<LogEntry>(msg);
+            if (!string.IsNullOrEmpty(entry.level) && entry.level.ToLower() == "error")
+            {
+                _lastError = entry.message;
+            }
+            if (!string.IsNullOrEmpty(entry.stt))
+                _sttEngine = entry.stt;
+            if (!string.IsNullOrEmpty(entry.tts))
+                _ttsEngine = entry.tts;
+        }
+        catch
+        {
+            // Ignore malformed log messages
+        }
+    }
+
+    void Update()
+    {
+        if (Input.GetKeyDown(toggleKey))
+            _visible = !_visible;
+
+        var receiver = FindObjectOfType<PADReceiver>();
+        _oscStatus = receiver != null ? "Listening" : "Not Listening";
+    }
+
+    void OnGUI()
+    {
+        if (!_visible)
+            return;
+
+        GUILayout.BeginArea(new Rect(10, 10, 420, 140), GUI.skin.box);
+        GUILayout.Label($"OSC: {_oscStatus}");
+        GUILayout.Label($"WebSocket: {_wsStatus}");
+        GUILayout.Label($"STT: {_sttEngine}");
+        GUILayout.Label($"TTS: {_ttsEngine}");
+        GUILayout.Label($"Last error: {_lastError}");
+        GUILayout.EndArea();
+    }
+
+    void OnDestroy()
+    {
+        try
+        {
+            _cts?.Cancel();
+            _ws?.Dispose();
+        }
+        catch { }
+    }
+
+    [Serializable]
+    class LogEntry
+    {
+        public string level;
+        public string message;
+        public string stt;
+        public string tts;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add `DiagnosticsHUD` Unity script to display OSC/WebSocket status, STT/TTS engines, and last error with F3 toggle
- Extend Python `LogManager` to broadcast log entries over WebSocket to the HUD

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afba3ee174832eb822cc016a87f01f