### PR TITLE
Add room loader and settings menu

### DIFF
--- a/config/room_config.json
+++ b/config/room_config.json
@@ -1,0 +1,3 @@
+{
+  "roomPrefab": "DefaultRoom"
+}

--- a/unity_project/Assets/Scripts/RoomLoader.cs
+++ b/unity_project/Assets/Scripts/RoomLoader.cs
@@ -1,0 +1,81 @@
+using UnityEngine;
+using System.IO;
+
+/// <summary>
+/// Serializable data structure for room configuration.
+/// </summary>
+[System.Serializable]
+public class RoomConfig
+{
+    public string roomPrefab = "DefaultRoom";
+}
+
+/// <summary>
+/// Loads a room prefab defined in <c>config/room_config.json</c> and
+/// positions the avatar and camera at the prefab's spawn point.
+/// </summary>
+public class RoomLoader : MonoBehaviour
+{
+    public Transform avatar;
+    public Vector3 cameraOffset = new Vector3(0f, 1.6f, -2f);
+
+    void Start()
+    {
+        var config = LoadConfig();
+        if (config == null || string.IsNullOrEmpty(config.roomPrefab)) return;
+
+        var prefab = Resources.Load<GameObject>(config.roomPrefab);
+        if (prefab == null)
+        {
+            Debug.LogWarning($"RoomLoader: Prefab '{config.roomPrefab}' not found in Resources.");
+            return;
+        }
+
+        var room = Instantiate(prefab);
+        var spawn = room.transform.Find("SpawnPoint");
+
+        if (spawn != null)
+        {
+            if (avatar == null)
+            {
+                var obj = GameObject.FindWithTag("Player");
+                avatar = obj != null ? obj.transform : null;
+            }
+
+            if (avatar != null)
+            {
+                avatar.position = spawn.position;
+            }
+
+            var cam = Camera.main;
+            if (cam != null)
+            {
+                cam.transform.position = spawn.position + cameraOffset;
+                if (avatar != null)
+                {
+                    cam.transform.LookAt(avatar);
+                }
+            }
+        }
+    }
+
+    RoomConfig LoadConfig()
+    {
+        try
+        {
+            var path = Path.Combine(Application.dataPath, "..", "..", "config", "room_config.json");
+            path = Path.GetFullPath(path);
+            if (!File.Exists(path))
+            {
+                return new RoomConfig();
+            }
+            var json = File.ReadAllText(path);
+            return JsonUtility.FromJson<RoomConfig>(json);
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogWarning($"RoomLoader: Failed to load config - {e.Message}");
+            return new RoomConfig();
+        }
+    }
+}

--- a/unity_project/Assets/Scripts/SettingsMenu.cs
+++ b/unity_project/Assets/Scripts/SettingsMenu.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.UI;
+using System.IO;
+
+/// <summary>
+/// Minimal settings menu allowing editing of the room configuration.
+/// </summary>
+public class SettingsMenu : MonoBehaviour
+{
+    public InputField roomPrefabInput;
+
+    string ConfigPath => Path.GetFullPath(Path.Combine(Application.dataPath, "..", "..", "config", "room_config.json"));
+
+    void Start()
+    {
+        Load();
+    }
+
+    /// <summary>
+    /// Loads current configuration into the UI input field.
+    /// </summary>
+    public void Load()
+    {
+        if (roomPrefabInput == null) return;
+        var config = ReadConfig();
+        roomPrefabInput.text = config.roomPrefab;
+    }
+
+    /// <summary>
+    /// Saves the configuration back to <c>room_config.json</c>.
+    /// </summary>
+    public void Save()
+    {
+        if (roomPrefabInput == null) return;
+        var config = new RoomConfig { roomPrefab = roomPrefabInput.text };
+        var json = JsonUtility.ToJson(config, true);
+        File.WriteAllText(ConfigPath, json);
+    }
+
+    RoomConfig ReadConfig()
+    {
+        try
+        {
+            if (File.Exists(ConfigPath))
+            {
+                var json = File.ReadAllText(ConfigPath);
+                return JsonUtility.FromJson<RoomConfig>(json);
+            }
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogWarning($"SettingsMenu: Failed to read config - {e.Message}");
+        }
+        return new RoomConfig();
+    }
+}


### PR DESCRIPTION
## Summary
- load room prefabs from `room_config.json` and spawn the avatar and camera
- provide settings menu to edit the room prefab in the config
- add default `room_config.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afba3e47a0832ea45e71fd19f84839