### PR TITLE
feat: add Unity speech streaming scripts

### DIFF
--- a/unity_project/Assets/Scripts/Audio/SttCapture.cs
+++ b/unity_project/Assets/Scripts/Audio/SttCapture.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+/// <summary>
+/// Captures microphone audio and streams it to a Python STT service via WebSocket.
+/// </summary>
+public class SttCapture : MonoBehaviour
+{
+    /// <summary>
+    /// Endpoint of the Python STT WebSocket server.
+    /// </summary>
+    public string sttEndpoint = "ws://localhost:5005/stt";
+
+    /// <summary>
+    /// Audio sampling rate in Hz.
+    /// </summary>
+    public int sampleRate = 16000;
+
+    /// <summary>
+    /// Size of audio chunks sent to the server in milliseconds.
+    /// </summary>
+    public int chunkMilliseconds = 250;
+
+    private ClientWebSocket socket;
+    private AudioClip micClip;
+    private int lastSample;
+
+    private async void Start()
+    {
+        socket = new ClientWebSocket();
+        await socket.ConnectAsync(new Uri(sttEndpoint), CancellationToken.None);
+
+        micClip = Microphone.Start(null, true, 1, sampleRate);
+        lastSample = 0;
+        StartCoroutine(StreamAudio());
+    }
+
+    private IEnumerator StreamAudio()
+    {
+        int chunkSize = sampleRate * chunkMilliseconds / 1000;
+        float[] floatBuffer = new float[chunkSize];
+        byte[] byteBuffer = new byte[chunkSize * 2]; // 16-bit PCM
+
+        while (true)
+        {
+            int pos = Microphone.GetPosition(null);
+            int diff = pos - lastSample;
+            if (diff < 0) diff += micClip.samples;
+
+            if (diff >= chunkSize)
+            {
+                micClip.GetData(floatBuffer, lastSample);
+                ConvertFloatsToBytes(floatBuffer, byteBuffer);
+                var sendTask = socket.SendAsync(new ArraySegment<byte>(byteBuffer), WebSocketMessageType.Binary, true, CancellationToken.None);
+                while (!sendTask.IsCompleted) yield return null;
+                lastSample = (lastSample + chunkSize) % micClip.samples;
+            }
+            yield return null;
+        }
+    }
+
+    private static void ConvertFloatsToBytes(float[] samples, byte[] bytes)
+    {
+        for (int i = 0; i < samples.Length; i++)
+        {
+            short value = (short)(Mathf.Clamp(samples[i], -1f, 1f) * short.MaxValue);
+            bytes[2 * i] = (byte)(value & 0xff);
+            bytes[2 * i + 1] = (byte)((value >> 8) & 0xff);
+        }
+    }
+
+    private async void OnDestroy()
+    {
+        if (socket != null)
+        {
+            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+            socket.Dispose();
+        }
+        if (Microphone.IsRecording(null))
+            Microphone.End(null);
+    }
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void AutoStart()
+    {
+        var go = new GameObject("SttCapture");
+        DontDestroyOnLoad(go);
+        go.AddComponent<SttCapture>();
+    }
+}

--- a/unity_project/Assets/Scripts/Audio/TtsPlayer.cs
+++ b/unity_project/Assets/Scripts/Audio/TtsPlayer.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+/// <summary>
+/// Streams text to a Python TTS endpoint and plays the returned WAV audio.
+/// Viseme timing data is exposed via <see cref="OnViseme"/> for lip-sync.
+/// </summary>
+public class TtsPlayer : MonoBehaviour
+{
+    [Serializable]
+    public class Viseme
+    {
+        public string viseme; // Identifier from the TTS backend
+        public float time;    // Time in seconds since start of audio
+    }
+
+    [Serializable]
+    private class TtsResponse
+    {
+        public string audioUrl; // URL for WAV data
+        public Viseme[] visemes; // Optional viseme timing data
+    }
+
+    /// <summary>
+    /// Invoked when a viseme should be displayed. Arguments: viseme id, time in seconds.
+    /// </summary>
+    public event Action<string, float> OnViseme;
+
+    /// <summary>
+    /// Endpoint of the Python TTS service returning JSON with audioUrl and visemes.
+    /// </summary>
+    public string ttsEndpoint = "http://localhost:5005/tts";
+
+    private AudioSource audioSource;
+
+    private void Awake()
+    {
+        audioSource = gameObject.AddComponent<AudioSource>();
+        audioSource.playOnAwake = false;
+    }
+
+    /// <summary>
+    /// Request speech for the provided text.
+    /// </summary>
+    public void Speak(string text)
+    {
+        StartCoroutine(RequestTts(text));
+    }
+
+    private IEnumerator RequestTts(string text)
+    {
+        string url = ttsEndpoint + "?text=" + UnityWebRequest.EscapeURL(text);
+        using (UnityWebRequest req = UnityWebRequest.Get(url))
+        {
+            yield return req.SendWebRequest();
+            if (req.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogError("TTS request failed: " + req.error);
+                yield break;
+            }
+            TtsResponse response = JsonUtility.FromJson<TtsResponse>(req.downloadHandler.text);
+            yield return StartCoroutine(PlayResponse(response));
+        }
+    }
+
+    private IEnumerator PlayResponse(TtsResponse response)
+    {
+        using (UnityWebRequest audioReq = UnityWebRequestMultimedia.GetAudioClip(response.audioUrl, AudioType.WAV))
+        {
+            yield return audioReq.SendWebRequest();
+            if (audioReq.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogError("Audio download failed: " + audioReq.error);
+                yield break;
+            }
+            AudioClip clip = DownloadHandlerAudioClip.GetContent(audioReq);
+            audioSource.clip = clip;
+            audioSource.Play();
+        }
+
+        if (response.visemes != null && response.visemes.Length > 0)
+        {
+            StartCoroutine(EmitVisemes(response.visemes));
+        }
+    }
+
+    private IEnumerator EmitVisemes(Viseme[] visemes)
+    {
+        float lastTime = 0f;
+        foreach (var v in visemes)
+        {
+            float wait = Mathf.Max(0f, v.time - lastTime);
+            lastTime = v.time;
+            yield return new WaitForSeconds(wait);
+            OnViseme?.Invoke(v.viseme, v.time);
+        }
+    }
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void AutoStart()
+    {
+        var go = new GameObject("TtsPlayer");
+        DontDestroyOnLoad(go);
+        go.AddComponent<TtsPlayer>();
+    }
+}


### PR DESCRIPTION
## Summary
- add `TtsPlayer` to stream TTS audio and surface viseme timings
- add `SttCapture` to capture mic audio and stream to Python STT service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afba3cadc4832ea28862b501abae6c