### PR TITLE
Add WebSocket bridge and Unity client

### DIFF
--- a/scripts/websocket_bridge.py
+++ b/scripts/websocket_bridge.py
@@ -1,0 +1,109 @@
+"""WebSocket bridge for emotion, transcript and UI events.
+
+This module exposes a small WebSocket server used to communicate between the
+Python backend and the Unity front end.  It provides three logical channels:
+
+- ``emotion``: Broadcasts avatar emotion parameters.
+- ``transcript``: Sends transcript strings from the speech system.
+- ``ui``: Receives UI events such as button clicks or settings changes.
+
+The server groups clients by the request path (``/emotion``, ``/transcript`` or
+``/ui``).  Utility functions are provided to publish messages to the
+corresponding channel from other Python modules.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict, Set
+
+import websockets
+from websockets.server import WebSocketServerProtocol
+
+# Known channels and their subscribers
+CHANNELS = ("emotion", "transcript", "ui")
+_clients: Dict[str, Set[WebSocketServerProtocol]] = {c: set() for c in CHANNELS}
+# Queue for UI events coming from the Unity client
+_ui_events: asyncio.Queue[dict] = asyncio.Queue()
+
+
+async def _handler(ws: WebSocketServerProtocol, path: str) -> None:
+    """WebSocket connection handler."""
+    channel = path.strip("/")
+    if channel not in _clients:
+        await ws.close()
+        return
+    _clients[channel].add(ws)
+    try:
+        async for message in ws:
+            if channel == "ui":
+                try:
+                    data = json.loads(message)
+                except Exception:
+                    continue
+                await _ui_events.put(data)
+    finally:
+        _clients[channel].discard(ws)
+
+
+async def _broadcast(channel: str, payload: Any) -> None:
+    """Send ``payload`` to all clients subscribed to ``channel``."""
+    if channel not in _clients:
+        return
+    message = json.dumps(payload)
+    dead: Set[WebSocketServerProtocol] = set()
+    for ws in _clients[channel]:
+        try:
+            await ws.send(message)
+        except Exception:
+            dead.add(ws)
+    for ws in dead:
+        _clients[channel].discard(ws)
+
+
+def publish(channel: str, payload: Any) -> None:
+    """Schedule ``payload`` to be sent to subscribers of ``channel``."""
+    asyncio.get_event_loop().create_task(_broadcast(channel, payload))
+
+
+def send_emotion(p: float, a: float, d: float) -> None:
+    """Convert PAD values to four common emotion parameters and broadcast."""
+    joy = max(0.0, min(1.0, (p + a) / 2))
+    angry = max(0.0, min(1.0, (a - p) / 2))
+    sorrow = max(0.0, min(1.0, (-p - a) / 2))
+    fun = max(0.0, min(1.0, (p - a) / 2))
+    publish("emotion", {"Joy": joy, "Angry": angry, "Sorrow": sorrow, "Fun": fun})
+
+
+def send_transcript(text: str) -> None:
+    """Broadcast a transcript string to all listeners."""
+    publish("transcript", {"text": text})
+
+
+async def get_ui_event() -> dict:
+    """Return the next UI event sent by the client."""
+    return await _ui_events.get()
+
+
+async def start(host: str = "0.0.0.0", port: int = 8765):
+    """Start the WebSocket server and return the server object."""
+    return await websockets.serve(_handler, host, port)
+
+
+async def _run_forever(host: str, port: int) -> None:
+    async with websockets.serve(_handler, host, port):
+        await asyncio.Future()  # run forever
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    asyncio.run(_run_forever("0.0.0.0", 8765))
+
+
+__all__ = [
+    "start",
+    "publish",
+    "send_emotion",
+    "send_transcript",
+    "get_ui_event",
+]

--- a/unity_project/Assets/Scripts/Net/WebSocketClient.cs
+++ b/unity_project/Assets/Scripts/Net/WebSocketClient.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEngine;
+
+/// <summary>
+/// Simple WebSocket client that subscribes to emotion and transcript channels
+/// from the Python backend and allows publishing UI events back to it.
+/// </summary>
+public class WebSocketClient : MonoBehaviour
+{
+    public string host = "ws://localhost:8765";
+
+    ClientWebSocket emotionSocket;
+    ClientWebSocket transcriptSocket;
+    ClientWebSocket uiSocket;
+
+    public event Action<EmotionMessage> EmotionReceived;
+    public event Action<string> TranscriptReceived;
+
+    [Serializable]
+    public struct EmotionMessage
+    {
+        public float Joy;
+        public float Angry;
+        public float Sorrow;
+        public float Fun;
+    }
+
+    async void Awake()
+    {
+        emotionSocket = await Connect("/emotion", HandleEmotion);
+        transcriptSocket = await Connect("/transcript", HandleTranscript);
+        uiSocket = await Connect("/ui", null);
+    }
+
+    async Task<ClientWebSocket> Connect(string path, Action<string> handler)
+    {
+        var ws = new ClientWebSocket();
+        try
+        {
+            await ws.ConnectAsync(new Uri(host + path), CancellationToken.None);
+            if (handler != null)
+                _ = ReceiveLoop(ws, handler);
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"WebSocket connect failed: {e.Message}");
+        }
+        return ws;
+    }
+
+    async Task ReceiveLoop(ClientWebSocket ws, Action<string> handler)
+    {
+        var buffer = new byte[1024];
+        while (ws.State == WebSocketState.Open)
+        {
+            var result = await ws.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            if (result.MessageType == WebSocketMessageType.Close)
+                break;
+            var msg = Encoding.UTF8.GetString(buffer, 0, result.Count);
+            handler?.Invoke(msg);
+        }
+    }
+
+    void HandleEmotion(string json)
+    {
+        try
+        {
+            var msg = JsonUtility.FromJson<EmotionMessage>(json);
+            EmotionReceived?.Invoke(msg);
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"Emotion parse error: {e.Message}");
+        }
+    }
+
+    void HandleTranscript(string json)
+    {
+        try
+        {
+            var wrapper = JsonUtility.FromJson<TranscriptWrapper>(json);
+            TranscriptReceived?.Invoke(wrapper.text);
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"Transcript parse error: {e.Message}");
+        }
+    }
+
+    [Serializable]
+    class TranscriptWrapper { public string text; }
+
+    public async void SendUIEvent(object payload)
+    {
+        if (uiSocket == null || uiSocket.State != WebSocketState.Open) return;
+        var json = JsonUtility.ToJson(payload);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        await uiSocket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, CancellationToken.None);
+    }
+
+    async void OnDestroy()
+    {
+        if (emotionSocket != null)
+            await emotionSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+        if (transcriptSocket != null)
+            await transcriptSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+        if (uiSocket != null)
+            await uiSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+    }
+}

--- a/unity_project/Assets/Scripts/PADReceiver.cs
+++ b/unity_project/Assets/Scripts/PADReceiver.cs
@@ -1,50 +1,32 @@
 using UnityEngine;
-using OscJack;
 
 /// <summary>
-/// Minimal OSC listener that maps PAD values from the Python app
-/// to Animator parameters. Requires the OscJack package
-/// (https://github.com/keijiro/OscJack).
+/// Maps emotion values received from the WebSocketClient to Animator parameters.
 /// </summary>
 public class PADReceiver : MonoBehaviour
 {
     public Animator animator;
+    public WebSocketClient client;
 
-    OscServer server;
-
-    void Awake()
+    void Start()
     {
-        // Listen on port 9000 which matches scripts/osc_bridge_stub.py
-        server = new OscServer(9000);
-        var disp = server.MessageDispatcher;
-        disp.AddCallback("/avatar/parameters/Joy", OnJoy);
-        disp.AddCallback("/avatar/parameters/Angry", OnAngry);
-        disp.AddCallback("/avatar/parameters/Sorrow", OnSorrow);
-        disp.AddCallback("/avatar/parameters/Fun", OnFun);
-    }
-
-    void OnJoy(string address, OscDataHandle data)
-    {
-        animator?.SetFloat("Joy", data.GetElementAsFloat(0));
-    }
-
-    void OnAngry(string address, OscDataHandle data)
-    {
-        animator?.SetFloat("Angry", data.GetElementAsFloat(0));
-    }
-
-    void OnSorrow(string address, OscDataHandle data)
-    {
-        animator?.SetFloat("Sorrow", data.GetElementAsFloat(0));
-    }
-
-    void OnFun(string address, OscDataHandle data)
-    {
-        animator?.SetFloat("Fun", data.GetElementAsFloat(0));
+        if (client == null)
+            client = FindObjectOfType<WebSocketClient>();
+        if (client != null)
+            client.EmotionReceived += OnEmotion;
     }
 
     void OnDestroy()
     {
-        server?.Dispose();
+        if (client != null)
+            client.EmotionReceived -= OnEmotion;
+    }
+
+    void OnEmotion(WebSocketClient.EmotionMessage msg)
+    {
+        animator?.SetFloat("Joy", msg.Joy);
+        animator?.SetFloat("Angry", msg.Angry);
+        animator?.SetFloat("Sorrow", msg.Sorrow);
+        animator?.SetFloat("Fun", msg.Fun);
     }
 }


### PR DESCRIPTION
## Summary
- Implement `websocket_bridge.py` WebSocket server broadcasting emotion and transcript data and capturing UI events
- Add Unity `WebSocketClient` to subscribe to emotion/transcript updates and send UI messages
- Refactor `PADReceiver` to use WebSocket client instead of direct OSC

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afba3ad7fc832e83f807b481f4a1fa