### PR TITLE
feat: add speech UI and settings menu

### DIFF
--- a/unity_project/Assets/Prefabs.meta
+++ b/unity_project/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6204f6faae94923bfadf3d23a1af6dd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity_project/Assets/Prefabs/UI.meta
+++ b/unity_project/Assets/Prefabs/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f3bfea02de44ab9b0e71a0129a6a238
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity_project/Assets/Prefabs/UI/SpeechCanvas.prefab
+++ b/unity_project/Assets/Prefabs/UI/SpeechCanvas.prefab
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: SpeechCanvas
+  m_Component:
+  - component: {fileID: 22400000}
+  - component: {fileID: 22300000}
+  - component: {fileID: 11400000}
+  - component: {fileID: 11500000}
+  - component: {fileID: 11400001}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &22400000
+RectTransform:
+  m_GameObject: {fileID: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 22400001}
+  - {fileID: 22400002}
+--- !u!223 &22300000
+Canvas:
+  m_GameObject: {fileID: 1}
+  m_RenderMode: 0
+--- !u!114 &11400000
+CanvasScaler:
+  m_GameObject: {fileID: 1}
+--- !u!115 &11500000
+GraphicRaycaster:
+  m_GameObject: {fileID: 1}
+--- !u!114 &11400001
+MonoBehaviour:
+  m_GameObject: {fileID: 1}
+  m_Script: {fileID: 11500000, guid: e6891264d57648c8a1c469c959a535c1, type: 3}
+  bubbleText: {fileID: 11400002}
+  subtitleText: {fileID: 11400003}
+  fadeDuration: 1
+  holdDuration: 2
+--- !u!1 &2
+GameObject:
+  m_Name: SpeechBubble
+  m_Component:
+  - component: {fileID: 22400001}
+  - component: {fileID: 11400002}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &22400001
+RectTransform:
+  m_GameObject: {fileID: 2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11400002
+MonoBehaviour:
+  m_GameObject: {fileID: 2}
+  m_Script: {fileID: 11500000, guid: f04445c50a92b9d4b9912c9f1005a028, type: 3}
+  m_text: ""
+--- !u!1 &3
+GameObject:
+  m_Name: Subtitle
+  m_Component:
+  - component: {fileID: 22400002}
+  - component: {fileID: 11400003}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &22400002
+RectTransform:
+  m_GameObject: {fileID: 3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11400003
+MonoBehaviour:
+  m_GameObject: {fileID: 3}
+  m_Script: {fileID: 11500000, guid: f04445c50a92b9d4b9912c9f1005a028, type: 3}
+  m_text: ""

--- a/unity_project/Assets/Prefabs/UI/SpeechCanvas.prefab.meta
+++ b/unity_project/Assets/Prefabs/UI/SpeechCanvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cefc68c7f2714786bfdd8059b90fbbb2
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity_project/Assets/Scripts/UI.meta
+++ b/unity_project/Assets/Scripts/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 437369c81ee3400ca19b00cf72ec32b8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity_project/Assets/Scripts/UI/SettingsMenu.cs
+++ b/unity_project/Assets/Scripts/UI/SettingsMenu.cs
@@ -1,0 +1,107 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.Networking;
+using TMPro;
+
+/// <summary>
+/// Fetches configuration from <c>scripts/settings_server.py</c> and allows
+/// switching STT/TTS engines and processing mode. Changes are posted back to
+/// the server and interested subsystems can be reloaded via UnityEvents.
+/// </summary>
+public class SettingsMenu : MonoBehaviour
+{
+    [SerializeField] private TMP_Dropdown sttDropdown;
+    [SerializeField] private TMP_Dropdown ttsDropdown;
+    [SerializeField] private TMP_Dropdown processingDropdown;
+    [SerializeField] private string serverUrl = "http://localhost:8765/config";
+
+    public UnityEvent onSttChanged;
+    public UnityEvent onTtsChanged;
+    public UnityEvent onProcessingChanged;
+
+    private void Start()
+    {
+        StartCoroutine(LoadConfig());
+        sttDropdown.onValueChanged.AddListener(_ => OnSttChanged());
+        ttsDropdown.onValueChanged.AddListener(_ => OnTtsChanged());
+        processingDropdown.onValueChanged.AddListener(_ => OnProcessingChanged());
+    }
+
+    private IEnumerator LoadConfig()
+    {
+        using UnityWebRequest req = UnityWebRequest.Get(serverUrl);
+        yield return req.SendWebRequest();
+        if (req.result == UnityWebRequest.Result.Success)
+        {
+            var cfg = JsonUtility.FromJson<Config>(req.downloadHandler.text);
+            Apply(cfg);
+        }
+        else
+        {
+            Debug.LogWarning($"Failed to load settings: {req.error}");
+        }
+    }
+
+    private void Apply(Config cfg)
+    {
+        if (!string.IsNullOrEmpty(cfg.STT_ENGINE))
+            SetDropdownValue(sttDropdown, cfg.STT_ENGINE);
+        if (!string.IsNullOrEmpty(cfg.TTS_ENGINE))
+            SetDropdownValue(ttsDropdown, cfg.TTS_ENGINE);
+        if (!string.IsNullOrEmpty(cfg.PROCESSING_MODE))
+            SetDropdownValue(processingDropdown, cfg.PROCESSING_MODE);
+    }
+
+    private void SetDropdownValue(TMP_Dropdown dropdown, string value)
+    {
+        int index = dropdown.options.FindIndex(o => o.text == value);
+        if (index >= 0)
+            dropdown.SetValueWithoutNotify(index);
+    }
+
+    private void OnSttChanged()
+    {
+        string value = sttDropdown.options[sttDropdown.value].text;
+        StartCoroutine(UpdateConfig("STT_ENGINE", value, onSttChanged));
+    }
+
+    private void OnTtsChanged()
+    {
+        string value = ttsDropdown.options[ttsDropdown.value].text;
+        StartCoroutine(UpdateConfig("TTS_ENGINE", value, onTtsChanged));
+    }
+
+    private void OnProcessingChanged()
+    {
+        string value = processingDropdown.options[processingDropdown.value].text;
+        StartCoroutine(UpdateConfig("PROCESSING_MODE", value, onProcessingChanged));
+    }
+
+    private IEnumerator UpdateConfig(string key, string value, UnityEvent callback)
+    {
+        string json = $"{{\"{key}\":\"{value}\"}}";
+        byte[] body = System.Text.Encoding.UTF8.GetBytes(json);
+        using UnityWebRequest req = new UnityWebRequest(serverUrl, UnityWebRequest.kHttpVerbPOST);
+        req.uploadHandler = new UploadHandlerRaw(body);
+        req.downloadHandler = new DownloadHandlerBuffer();
+        req.SetRequestHeader("Content-Type", "application/json");
+        yield return req.SendWebRequest();
+        if (req.result == UnityWebRequest.Result.Success || req.responseCode == 204)
+        {
+            callback?.Invoke();
+        }
+        else
+        {
+            Debug.LogWarning($"Failed to update settings: {req.error}");
+        }
+    }
+
+    [System.Serializable]
+    private class Config
+    {
+        public string STT_ENGINE;
+        public string TTS_ENGINE;
+        public string PROCESSING_MODE;
+    }
+}

--- a/unity_project/Assets/Scripts/UI/SettingsMenu.cs.meta
+++ b/unity_project/Assets/Scripts/UI/SettingsMenu.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c62fc20383f8478d8a09627bcbc35a54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/unity_project/Assets/Scripts/UI/SpeechUI.cs
+++ b/unity_project/Assets/Scripts/UI/SpeechUI.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using TMPro;
+using System.Collections;
+
+/// <summary>
+/// Displays dialogue text in both a speech bubble and subtitles then fades them out.
+/// </summary>
+public class SpeechUI : MonoBehaviour
+{
+    [SerializeField] private TextMeshProUGUI bubbleText;
+    [SerializeField] private TextMeshProUGUI subtitleText;
+    [SerializeField] private float fadeDuration = 1f;
+    [SerializeField] private float holdDuration = 2f;
+
+    private Coroutine routine;
+
+    /// <summary>
+    /// Show text coming from the Python backend.
+    /// </summary>
+    public void Show(string text)
+    {
+        if (routine != null)
+            StopCoroutine(routine);
+        routine = StartCoroutine(Display(text));
+    }
+
+    private IEnumerator Display(string text)
+    {
+        if (bubbleText != null) bubbleText.text = text;
+        if (subtitleText != null) subtitleText.text = text;
+        SetAlpha(1f);
+        yield return new WaitForSeconds(holdDuration);
+        float t = 0f;
+        while (t < fadeDuration)
+        {
+            t += Time.deltaTime;
+            float a = Mathf.Lerp(1f, 0f, t / fadeDuration);
+            SetAlpha(a);
+            yield return null;
+        }
+        if (bubbleText != null) bubbleText.text = string.Empty;
+        if (subtitleText != null) subtitleText.text = string.Empty;
+        routine = null;
+    }
+
+    private void SetAlpha(float a)
+    {
+        if (bubbleText != null)
+        {
+            var c = bubbleText.color;
+            c.a = a;
+            bubbleText.color = c;
+        }
+        if (subtitleText != null)
+        {
+            var c = subtitleText.color;
+            c.a = a;
+            subtitleText.color = c;
+        }
+    }
+}

--- a/unity_project/Assets/Scripts/UI/SpeechUI.cs.meta
+++ b/unity_project/Assets/Scripts/UI/SpeechUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6891264d57648c8a1c469c959a535c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add SpeechCanvas prefab with speech bubble and subtitle TextMeshPro elements
- implement SpeechUI for displaying and fading dialogue text
- create SettingsMenu to fetch/update STT, TTS, and processing mode via settings server

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afba398bfc832e83fb1f658722166c