### PR TITLE
Add basic vision and audio monitoring stubs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,11 @@ LLAMA_MODEL_PATH=
 # (e.g. VSeeFace) if you wish to drive the avatar from the PAD data.
 OSC_HOST=127.0.0.1
 OSC_PORT=9000
+
+# Toggle optional vision and audio integrations
+VISION_WATCH_ENABLED=true
+AUDIO_INTEREST_ENABLED=true
+
+# Optional audio detection parameters
+AUDIO_VOLUME_THRESHOLD=0.02
+AUDIO_KEYWORDS=clair,assistant,buddy

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,8 @@ python-dotenv>=0.21.0
 # Open‑source LLM support (requires a local .gguf model)
 llama-cpp-python>=0.2.0
 openai>=1.0.0  # required only for online mode; safe to omit if running offline
+
+# Optional vision and audio integrations
+opencv-python>=4.8.0
+sounddevice>=0.4.5
+SpeechRecognition>=3.10.0

--- a/scripts/audio_interest_stub.py
+++ b/scripts/audio_interest_stub.py
@@ -1,33 +1,75 @@
 #!/usr/bin/env python3
-"""Simulated audio interest trigger for Clair.
+"""Audio interest monitor for Clair.
 
-This stub mimics audio analysis by periodically generating events such
-as the user repeatedly calling Clair's name or interesting sounds
-captured by a microphone.  In a real system you would integrate
-wake‑word detection, speaker diarisation and sound classification.
+Record microphone input using ``sounddevice`` and trigger events when
+volume or configured keywords exceed thresholds.  Keyword detection is
+performed with the optional ``SpeechRecognition`` package.
+
+Set ``AUDIO_INTEREST_ENABLED=false`` in the ``.env`` file to disable this
+feature.
 """
 
-import random
-import time
+import os
+import queue
+from typing import List
+from dotenv import load_dotenv
 
-def main():
-    names = ["clair", "assistant", "buddy"]
-    sounds = ["doorbell", "phone ringing", "kitchen timer", "alarm"]
-    print("Starting simulated audio interest monitor. Press Ctrl+C to stop.")
-    count = 0
-    try:
-        while True:
-            time.sleep(6)
-            # Alternate between name calls and interesting sounds
-            if count % 2 == 0:
-                name = random.choice(names)
-                print(f"Audio: Heard '{name}' called repeatedly – getting user's attention.\n")
-            else:
-                sound = random.choice(sounds)
-                print(f"Audio: Detected sound '{sound}' – potential event to handle.\n")
-            count += 1
-    except KeyboardInterrupt:
-        print("Audio interest monitor stopped.")
+
+def main() -> None:
+    load_dotenv()
+    if os.getenv("AUDIO_INTEREST_ENABLED", "true").lower() != "true":
+        print("Audio interest monitor is disabled via environment variable.")
+        return
+
+    import numpy as np
+    import sounddevice as sd
+
+    try:  # Keyword detection is optional
+        import speech_recognition as sr
+    except Exception:  # pragma: no cover - handled gracefully
+        sr = None
+
+    volume_threshold = float(os.getenv("AUDIO_VOLUME_THRESHOLD", "0.02"))
+    keywords: List[str] = [
+        k.strip().lower() for k in os.getenv("AUDIO_KEYWORDS", "clair,assistant,buddy").split(",")
+    ]
+    sample_rate = 16_000
+    recognizer = sr.Recognizer() if sr else None
+    if recognizer is None:
+        print("Keyword detection disabled (SpeechRecognition not installed).")
+
+    q: queue.Queue[np.ndarray] = queue.Queue()
+
+    def callback(indata, frames, time, status) -> None:  # noqa: D401
+        """Receive audio blocks from sounddevice."""
+        if status:
+            print(status)
+        q.put(indata.copy())
+
+    with sd.InputStream(channels=1, samplerate=sample_rate, callback=callback):
+        print("Audio interest monitor started. Press Ctrl+C to stop.")
+        try:
+            while True:
+                data = q.get()
+                volume = float(np.linalg.norm(data) / len(data))
+                if volume > volume_threshold:
+                    print("Audio: Volume threshold exceeded.")
+                    if recognizer:
+                        data_int16 = np.int16(data * 32767)
+                        audio = sr.AudioData(data_int16.tobytes(), sample_rate, 2)
+                        try:
+                            text = recognizer.recognize_google(audio).lower()
+                            for kw in keywords:
+                                if kw in text:
+                                    print(f"Audio: Keyword '{kw}' detected.")
+                                    break
+                        except sr.UnknownValueError:
+                            pass
+                        except sr.RequestError:
+                            print("Audio: Speech recognition service unavailable.")
+        except KeyboardInterrupt:
+            pass
+    print("Audio interest monitor stopped.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- capture camera frames with OpenCV and report face or scene changes
- monitor microphone input for loud volumes or keywords using sounddevice
- expose `.env` flags to toggle vision and audio monitors and document new dependencies

## Testing
- `python -m py_compile scripts/vision_watch_stub.py scripts/audio_interest_stub.py`
- `python scripts/vision_watch_stub.py` *(fails: can't open camera)*
- `python scripts/audio_interest_stub.py` *(fails: Error querying device -1)*

------
https://chatgpt.com/codex/tasks/task_e_68ace2ded65c832e9fff87c45a20194b