### PR TITLE
Clamp dialogue PAD to moderate range

### DIFF
--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -11,3 +11,10 @@ Clair ships with a word-replacement filter pipeline.
 - **dev0** – filter disabled for local testing.
 
 The replacement tables for each level live in `scripts/filter_system.py`.
+
+## Conversational Tone Limits
+
+During dialogue the emotion orchestrator clamps valence, arousal and
+dominance to ±0.6.  Downstream speech and animation systems reference the
+clamped values so Clair's vocal delivery and facial expressions remain
+within everyday intensity.

--- a/scripts/speech_loop_stub.py
+++ b/scripts/speech_loop_stub.py
@@ -646,10 +646,7 @@ def main() -> None:
         active_emotions = update_emotions(active_emotions, user_input)
         # Compute PAD from active emotions
         pad = pad_from_emotions(active_emotions, emo_defs)
-        try:
-            send_pad(pad["P"], pad["A"], pad["D"])
-        except Exception:
-            pass
+
         # Apply contact feelings adjustment (bias mood by relationship)
         current_contact_id = "riley"  # in this demo we assume the user is Riley
         contact = contact_manager.get(current_contact_id)
@@ -663,6 +660,16 @@ def main() -> None:
             pad["P"] = max(-1.0, min(1.0, pad["P"] + 0.15 * cP))
             pad["A"] = max(-1.0, min(1.0, pad["A"] + 0.15 * cA))
             pad["D"] = max(-1.0, min(1.0, pad["D"] + 0.15 * cD))
+
+        # Clamp PAD to everyday conversational intensity
+        for key in ("P", "A", "D"):
+            pad[key] = max(-0.6, min(0.6, pad[key]))
+
+        try:
+            send_pad(pad["P"], pad["A"], pad["D"])
+        except Exception:
+            pass
+
         # Select a response state
         response_state = choose_state_from_pad(pad)
         style = style_from_pad(pad)

--- a/unity_project/Assets/Scripts/PADReceiver.cs
+++ b/unity_project/Assets/Scripts/PADReceiver.cs
@@ -27,27 +27,32 @@ public class PADReceiver : MonoBehaviour
 
     void OnJoy(string address, OscDataHandle data)
     {
-        animator?.SetFloat("Joy", data.GetElementAsFloat(0));
+        float v = Mathf.Clamp(data.GetElementAsFloat(0), -0.6f, 0.6f);
+        animator?.SetFloat("Joy", v);
     }
 
     void OnAngry(string address, OscDataHandle data)
     {
-        animator?.SetFloat("Angry", data.GetElementAsFloat(0));
+        float v = Mathf.Clamp(data.GetElementAsFloat(0), -0.6f, 0.6f);
+        animator?.SetFloat("Angry", v);
     }
 
     void OnSorrow(string address, OscDataHandle data)
     {
-        animator?.SetFloat("Sorrow", data.GetElementAsFloat(0));
+        float v = Mathf.Clamp(data.GetElementAsFloat(0), -0.6f, 0.6f);
+        animator?.SetFloat("Sorrow", v);
     }
 
     void OnFun(string address, OscDataHandle data)
     {
-        animator?.SetFloat("Fun", data.GetElementAsFloat(0));
+        float v = Mathf.Clamp(data.GetElementAsFloat(0), -0.6f, 0.6f);
+        animator?.SetFloat("Fun", v);
     }
 
     void OnMouthOpen(string address, OscDataHandle data)
     {
-        animator?.SetFloat("MouthOpen", data.GetElementAsFloat(0));
+        float v = Mathf.Clamp(data.GetElementAsFloat(0), -0.6f, 0.6f);
+        animator?.SetFloat("MouthOpen", v);
     }
 
     void OnDestroy()


### PR DESCRIPTION
## Summary
- Clamp valence, arousal and dominance to ±0.6 in EmotionOrchestrator and expose clamped PAD in effects
- Limit PAD in speech_loop_stub and Unity PADReceiver so expressions stay mild
- Document conversational tone caps

## Testing
- `PYTHONPATH=. pytest tests/test_emotion_orchestrator.py -q`
- `PYTHONPATH=. pytest -q` *(fails: IndentationError: unexpected indent in scripts/curiosity_engine.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b103ede6e0832ea31c6da89da25d23