### PR TITLE
Add dialogue regulator tests and PAD clamping checks

### DIFF
--- a/scripts/dialogue_regulator.py
+++ b/scripts/dialogue_regulator.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Utilities for constraining LLM replies to conversational bounds.
+
+This module exposes :func:`normalize_reply` which ensures that raw
+model responses adhere to simple conversational rules. The function
+keeps replies concise by trimming excess sentences and characters while
+optionally emphasising excitement for highly aroused states.
+"""
+
+import re
+from typing import Optional
+
+try:  # pragma: no cover - optional import
+    from emotion.orchestrator import PAD
+except Exception:  # pragma: no cover
+    PAD = None  # type: ignore
+
+DEFAULT_MAX_CHARS = 160
+DEFAULT_MAX_SENTENCES = 3
+
+def _truncate_to_char_limit(text: str, max_chars: int) -> str:
+    """Trim ``text`` to ``max_chars`` without cutting words."""
+    if len(text) <= max_chars:
+        return text
+    trimmed = text[:max_chars].rstrip()
+    if " " in trimmed:
+        trimmed = trimmed[: trimmed.rfind(" ")].rstrip()
+    return trimmed
+
+def normalize_reply(
+    reply: str,
+    pad: Optional["PAD"] = None,
+    *,
+    max_chars: int = DEFAULT_MAX_CHARS,
+    max_sentences: int = DEFAULT_MAX_SENTENCES,
+) -> str:
+    """Return a version of ``reply`` that fits conversational limits.
+
+    The text is normalised as follows:
+
+    * Leading/trailing whitespace is stripped.
+    * Only the first ``max_sentences`` sentences are kept.
+    * The result is trimmed to ``max_chars`` characters without breaking
+      words.
+    * When ``pad`` indicates high arousal the reply ends with an
+      exclamation mark to reflect an excited tone.
+    """
+
+    reply = reply.strip()
+    if not reply:
+        return reply
+
+    sentences = re.split(r"(?<=[.!?]) +", reply)
+    if len(sentences) > max_sentences:
+        sentences = sentences[:max_sentences]
+    normalised = " ".join(sentences).strip()
+    normalised = _truncate_to_char_limit(normalised, max_chars)
+
+    if pad is not None and getattr(pad, "arousal", 0.0) > 0.7:
+        normalised = normalised.rstrip(".!") + "!"
+    return normalised
+
+__all__ = ["normalize_reply", "DEFAULT_MAX_CHARS", "DEFAULT_MAX_SENTENCES"]

--- a/tests/test_dialogue_regulator.py
+++ b/tests/test_dialogue_regulator.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "scripts"))
+
+from dialogue_regulator import normalize_reply
+from emotion.orchestrator import PAD
+
+
+def test_normalize_reply_trims_and_splits():
+    long_text = (
+        "This is the first sentence. "
+        "This second sentence is intentionally made very long so that it exceeds the character limit "
+        "and needs to be truncated accordingly. "
+        "A third sentence should be removed entirely."
+    )
+    result = normalize_reply(long_text, max_chars=120, max_sentences=2)
+    assert len(result) <= 120
+    assert result.count(".") <= 2
+    assert "third sentence" not in result.lower()
+
+
+def test_normalize_reply_single_word():
+    assert normalize_reply("Hello") == "Hello"
+
+
+def test_normalize_reply_high_arousal_exclaimed_and_clamped():
+    pad = PAD(pleasure=0.0, arousal=1.0, dominance=0.0)
+    text = (
+        "This news is incredibly exciting and I simply cannot contain my enthusiasm about how wonderful "
+        "everything is right now."
+    )
+    result = normalize_reply(text, pad=pad, max_chars=80)
+    assert result.endswith("!")
+    assert len(result) <= 80


### PR DESCRIPTION
## Summary
- add `normalize_reply` utility to keep replies concise and excited when arousal is high
- cover dialogue regulator with trimming, splitting, and high-arousal tests
- verify emotion orchestrator clamps extreme PAD inputs

## Testing
- `pytest tests/test_dialogue_regulator.py tests/test_emotion_orchestrator.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'scripts')*

------
https://chatgpt.com/codex/tasks/task_e_68b103eddf18832eaf6638c531ef5699