### PR TITLE
Add dialogue regulator for concise LLM replies

### DIFF
--- a/config/emotion.json
+++ b/config/emotion.json
@@ -11,5 +11,9 @@
       "humor": {"tau_hours": 8, "weight": 0.9},
       "minor_slight": {"tau_hours": 4, "weight": 0.8}
     }
+  },
+  "dialogue": {
+    "max_sentences": 3,
+    "avg_words_per_sentence": 15
   }
 }

--- a/scripts/dialogue_regulator.py
+++ b/scripts/dialogue_regulator.py
@@ -1,0 +1,47 @@
+"""Normalize LLM replies to respect simple dialogue limits."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from textwrap import TextWrapper
+from typing import Dict
+
+CONFIG_PATH = Path("config/emotion.json")
+
+def _load_limits() -> Dict[str, int]:
+    if CONFIG_PATH.exists():
+        try:
+            data = json.loads(CONFIG_PATH.read_text())
+            return data.get("dialogue", {})
+        except Exception:
+            return {}
+    return {}
+
+
+def normalize_reply(text: str, emotion: Dict) -> str:
+    """Trim or split overly long replies based on config limits."""
+    limits = _load_limits()
+    max_sentences = int(limits.get("max_sentences", 3))
+    avg_words = int(limits.get("avg_words_per_sentence", 15))
+
+    raw_sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    wrapper = TextWrapper(width=avg_words * 8, break_long_words=False, replace_whitespace=False)
+    normalized = []
+    for raw in raw_sentences:
+        for sent in wrapper.wrap(raw):
+            words = sent.strip().split()
+            while len(words) > avg_words:
+                chunk = " ".join(words[:avg_words]).rstrip(",;:") + "."
+                normalized.append(chunk)
+                words = words[avg_words:]
+            if words:
+                tail = " ".join(words).rstrip(",;:")
+                if not tail.endswith(('.', '!', '?')):
+                    tail += '.'
+                normalized.append(tail)
+    normalized = [s for s in normalized if s]
+    normalized = normalized[:max_sentences]
+    return " ".join(normalized)
+
+__all__ = ["normalize_reply"]

--- a/scripts/llm_adapter.py
+++ b/scripts/llm_adapter.py
@@ -7,6 +7,7 @@ import re
 from typing import Dict, List, Optional
 
 from .prompt_manager import build_messages
+from .dialogue_regulator import normalize_reply
 
 try:  # pragma: no cover - optional
     import openai
@@ -54,6 +55,7 @@ def generate_response(
     tool_results: Optional[str] = None,
     human_mode: bool = True,
     style: Optional[Dict[str, float]] = None,
+    emotion: Optional[Dict[str, float]] = None,
 ) -> Optional[str]:
     """Generate a reply to the user's input using a local or online LLM."""
     messages = build_messages(
@@ -182,7 +184,7 @@ def generate_response(
         reply = _strip_ai_mentions(reply)
     if style and style.get("interjection"):
         reply = f"{style['interjection']} {reply}".strip()
-    return reply
+    return normalize_reply(reply, emotion or {})
 
 
 __all__ = ["generate_response"]

--- a/tests/test_dialogue_regulator.py
+++ b/tests/test_dialogue_regulator.py
@@ -1,0 +1,19 @@
+import re
+from scripts.dialogue_regulator import normalize_reply
+
+
+def _count_sentences(text: str) -> int:
+    return len([s for s in re.split(r"(?<=[.!?])\s+", text.strip()) if s])
+
+
+def test_truncates_to_max_sentences():
+    text = "One. Two. Three. Four."
+    out = normalize_reply(text, {})
+    assert _count_sentences(out) == 3
+
+
+def test_splits_long_sentences():
+    long_sentence = " ".join(["word"] * 40) + "."
+    out = normalize_reply(long_sentence, {})
+    sentences = [s for s in re.split(r"(?<=[.!?])\s+", out.strip()) if s]
+    assert all(len(s.split()) <= 15 for s in sentences)


### PR DESCRIPTION
## Summary
- limit dialogue with new `normalize_reply` heuristics and config-driven thresholds
- ensure `llm_adapter.generate_response` normalizes replies before returning
- document tunable dialogue limits in `emotion.json`

## Testing
- `PYTHONPATH=. pytest tests/test_dialogue_regulator.py`
- `PYTHONPATH=. pytest` *(fails: IndentationError in scripts/curiosity_engine.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b103eda338832ea6eaf4ded89b0717