### PR TITLE
Add sentiment fallback model and document licensing

### DIFF
--- a/docs/Filters.md
+++ b/docs/Filters.md
@@ -11,3 +11,16 @@ Clair ships with a word-replacement filter pipeline.
 - **dev0** – filter disabled for local testing.
 
 The replacement tables for each level live in `scripts/filter_system.py`.
+
+## Optional sentiment model
+
+Deployments that cannot query a full LLM may enable a tiny sentiment
+classifier to supply valence hints to the emotion system.  The
+`distilroberta-base-go-emotions` model from HuggingFace is bundled as an
+optional dependency and loaded by `scripts/emotion_guard.py`.  Its
+outputs are mapped to positive or negative scores which the emotion
+orchestrator uses for pleasure (valence) adjustments.
+
+The model is distributed under the MIT license.  Verify that any use of
+this optional component complies with its license and with North
+American content regulations.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,9 @@ paho-mqtt>=1.6.1
 # Open‑source LLM support (requires a local .gguf model)
 llama-cpp-python>=0.2.0
 openai>=1.0.0  # required only for online mode; safe to omit if running offline
+# Optional sentiment analysis fallback
+transformers>=4.37.0
+torch>=2.0.0
 # Experimental learning framework
 dspy>=3.0.2
 codex/resolve-conflict-in-readme.md-g7qctv

--- a/scripts/emotion_guard.py
+++ b/scripts/emotion_guard.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Fallback sentiment guard using a small HuggingFace model.
+
+The primary system may use a full LLM to infer user sentiment.  When
+that is not available this module loads ``distilroberta-base-go-emotions``
+and maps its emotion labels to a simple positive/negative score.  The
+result is fed into the :class:`emotion.orchestrator.EmotionOrchestrator`
+to influence valence (pleasure) adjustments.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+try:  # pragma: no cover - transformers is optional
+    from transformers import pipeline  # type: ignore
+except Exception:  # pragma: no cover
+    pipeline = None  # type: ignore
+
+from emotion.orchestrator import EmotionOrchestrator, PAD
+
+# Labels grouped by valence.  These are a coarse mapping of the
+# GoEmotions taxonomy.
+_POSITIVE: set[str] = {
+    "admiration",
+    "amusement",
+    "approval",
+    "caring",
+    "curiosity",
+    "desire",
+    "excitement",
+    "gratitude",
+    "joy",
+    "love",
+    "optimism",
+    "pride",
+    "relief",
+}
+
+_NEGATIVE: set[str] = {
+    "anger",
+    "annoyance",
+    "disappointment",
+    "disapproval",
+    "disgust",
+    "embarrassment",
+    "fear",
+    "grief",
+    "nervousness",
+    "remorse",
+    "sadness",
+}
+
+
+@dataclass
+class EmotionGuard:
+    """Compute valence using a tiny sentiment classifier."""
+
+    model_name: str = "bhadresh-savani/distilroberta-base-go-emotions"
+
+    def __post_init__(self) -> None:  # pragma: no cover - model load
+        self._clf = None
+        if pipeline is not None:
+            try:
+                self._clf = pipeline(
+                    "text-classification", model=self.model_name, top_k=None
+                )
+            except Exception:
+                self._clf = None
+        self._orchestrator = EmotionOrchestrator()
+
+    # ------------------------------------------------------------------
+    def _score(self, text: str) -> float:
+        """Return a valence score in ``[-1, 1]``."""
+        if self._clf is None:
+            return 0.0
+        results: List[Dict[str, Any]] = self._clf(text)[0]
+        pos = sum(r["score"] for r in results if r["label"] in _POSITIVE)
+        neg = sum(r["score"] for r in results if r["label"] in _NEGATIVE)
+        return max(-1.0, min(1.0, pos - neg))
+
+    def analyse(self, text: str, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        """Analyse ``text`` and return orchestrator effects.
+
+        ``context`` may contain existing affect tags which will be
+        forwarded to the orchestrator.  The computed valence drives the
+        pleasure component of the PAD model.
+        """
+
+        context = context or {}
+        val = self._score(text)
+        pad = PAD(pleasure=val, arousal=0.0, dominance=0.0)
+        appraisal = self._orchestrator.appraise(text, context)
+        bundle = self._orchestrator.bundle(appraisal, pad, None, None)
+        stance = self._orchestrator.stance(bundle, pad, None, None)
+        return self._orchestrator.effects(bundle, stance, pad, appraisal.get("tags", []))
+
+
+__all__ = ["EmotionGuard"]


### PR DESCRIPTION
## Summary
- add optional sentiment analysis dependencies
- implement `EmotionGuard` that maps `distilroberta-base-go-emotions` outputs to valence and feeds the orchestrator
- document optional model and MIT licence in Filters guide

## Testing
- `PYTHONPATH=. pytest -q` *(fails: IndentationError in `scripts/curiosity_engine.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f69ebe50832e966f80691c9b76a5